### PR TITLE
Fix base href for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Publish
         run: dotnet publish VoidStrike/VoidStrike.csproj --no-restore --configuration Release --output publish
 
+      - name: Set base href for GitHub Pages subdirectory
+        run: sed -i 's|<base href="/" />|<base href="/Void-Strike/" />|g' publish/wwwroot/index.html
+
       - name: Add .nojekyll
         run: touch publish/wwwroot/.nojekyll
 


### PR DESCRIPTION
## Summary

- Fix blank page on GitHub Pages by setting correct base href during build
- Blazor WASM requires base href to match the subdirectory path when deployed without a custom domain
- The workflow now replaces the base href from / to /Void-Strike/ after publish

## Type of Change

- Bug fix